### PR TITLE
fix bluetooth mic acdb id

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -61,7 +61,7 @@
                 <device name="SND_DEVICE_IN_HANDSET_DMIC_AEC_NS" acdb_id="41"/>
                 <device name="SND_DEVICE_IN_BT_SCO_MIC" acdb_id="8"/>
                 <device name="SND_DEVICE_IN_BT_SCO_MIC_NREC" acdb_id="8"/>
-                <device name="SND_DEVICE_IN_BT_SCO_MIC_WB" acdb_id="4"/>
+                <device name="SND_DEVICE_IN_BT_SCO_MIC_WB" acdb_id="8"/>
                 <device name="SND_DEVICE_IN_CAMCORDER_MIC" acdb_id="21"/>
                 <device name="SND_DEVICE_IN_SPEAKER_MIC" acdb_id="8"/>
                 <device name="SND_DEVICE_IN_SPEAKER_DMIC_AEC_NS" acdb_id="41"/>


### PR DESCRIPTION
fixes the Bluetooth mic problem that caused no sound after 3 minutes of voice call via Bluetooth headset. Thanks to infrag for the fix.